### PR TITLE
Add CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+mylabathula.com


### PR DESCRIPTION
- Without the CNAME file, going to `stephenmylabathula.github.io` doesn't
  redirect to `mylabathula.com`
- Also, Google has indexed `stephenmylabathula.github.io` and not `mylabathula.com`